### PR TITLE
Two efficiency improvements both involving class ExpectedMessageStore...

### DIFF
--- a/src/main/java/com/jeff/fischman/exercise/messages/Trade.java
+++ b/src/main/java/com/jeff/fischman/exercise/messages/Trade.java
@@ -7,7 +7,6 @@ public class Trade implements Message {
     private long _quantity;
     private BigDecimal _price;
 
-
     public Trade(long quantity, BigDecimal price) {
         _quantity = quantity;
         _price = price;
@@ -40,4 +39,8 @@ public class Trade implements Message {
                 Objects.equals(_price, trade._price);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(_quantity, _price);
+    }
 }


### PR DESCRIPTION
 - By using a ConcurrentHashMap instead of a HashMap, it is no longer necessary to make
   a copy of the values when we want to create a Stream<Order> in method getMissingChangedOrderStream().
   Prior to this change, we made a copy of the values because without it, a change to the map
   while doing the iteration would have led to a ConcurrentModificationException
 - Also, _expectedTrades was changed from a LinkedList<Trade> to a HashSet<Trade> making removal faster.
   This necessitated a change in Trade to add a hash() method.

A new test was also created in ExpectedMessageStoreTests to verify that the ConcurrentHashMap provides the
protection expected. Existing tests were able to verify that the HashSet<Trade> change worked as expected.